### PR TITLE
fix(`PromiseReleaseReconciler`): Fail if installing `Promise` fails

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/controllers/promiserelease_controller_test.go
+++ b/controllers/promiserelease_controller_test.go
@@ -12,8 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PromiseReleaseController", func() {
@@ -268,6 +271,56 @@ var _ = Describe("PromiseReleaseController", func() {
 						Expect(promiseRelease.GetFinalizers()).To(ConsistOf("kratix.io/promise-cleanup"))
 					})
 				})
+
+				When("the Promise manifest is invalid", func() {
+					var (
+						promiseNamespacedName types.NamespacedName
+						eventRecorder         *record.FakeRecorder
+					)
+
+					BeforeEach(func() {
+						promiseNamespacedName = types.NamespacedName{
+							Name: promise.Name,
+							// Note: Promise is cluster-scoped
+						}
+
+						fakeK8sClient = &mockPromiseCtrlRuntimeClient{
+							Client:  fakeK8sClient,
+							promise: promise.Name,
+							mockErr: errors.NewInvalid( // Create mock error for invalid promise
+								promise.GroupVersionKind().GroupKind(),
+								promise.Name,
+								field.ErrorList{},
+							),
+						}
+
+						eventRecorder = record.NewFakeRecorder(1024)
+
+						reconciler = &controllers.PromiseReleaseReconciler{
+							Client:         fakeK8sClient,
+							Scheme:         scheme.Scheme,
+							PromiseFetcher: fakeFetcher,
+							Log:            ctrl.Log.WithName("controllers").WithName("PromiseRelease"),
+							EventRecorder:  eventRecorder,
+						}
+
+						err := fakeK8sClient.Create(context.TODO(), &promiseRelease)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("fails the PromiseRelease's reconciliation", func() {
+						_, err := t.reconcileUntilCompletion(reconciler, &promiseRelease)
+						Expect(err).To(HaveOccurred())
+						Expect(eventRecorder.Events).To(Receive(ContainSubstring(
+							fmt.Sprintf("Promise.platform.kratix.io %q is invalid", promise.Name)),
+						))
+					})
+
+					It("doesn't create the Promise", func() {
+						err := fakeK8sClient.Get(context.TODO(), promiseNamespacedName, promise)
+						Expect(err).To(HaveOccurred())
+					})
+				})
 			})
 		})
 	})
@@ -403,3 +456,29 @@ var _ = Describe("PromiseReleaseController", func() {
 		})
 	})
 })
+
+type mockPromiseCtrlRuntimeClient struct {
+	client.Client
+	promise string              // Name of the Promise
+	mockErr *errors.StatusError // Error returned by this client when expected conditions meet
+}
+
+// Create mocks the client.Client's Create method in mockPromiseCtrlRuntimeClient
+//
+// If the object being created is of kind "Promise", and the name matches, it returns a predefined error. Else, it
+// invokes the client.Client 's Create method.
+func (m *mockPromiseCtrlRuntimeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	// Parse the object as "Promise"
+	if _, ok := obj.(*v1alpha1.Promise); !ok {
+		// When the object is not a Promise, invoke the client.Client's Create method
+		return m.Client.Create(ctx, obj)
+	}
+
+	// Check if the object's name matches the expected name
+	if obj.GetName() == m.promise {
+		return m.mockErr
+	}
+
+	// When the object doesn't match the required Promise, invoke the client.Client's Create method
+	return m.Client.Create(ctx, obj)
+}

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func main() {
 			Client:         mgr.GetClient(),
 			Scheme:         mgr.GetScheme(),
 			PromiseFetcher: &fetchers.URLFetcher{},
+			EventRecorder:  mgr.GetEventRecorderFor("PromiseReleaseController"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "PromiseRelease")
 			os.Exit(1)


### PR DESCRIPTION
## Description
Fail the `PromiseReleaseReconciler` if there is an error installing the referenced promise.

Add an event to PromiseRelease to state the reason for the failure of installing Promise. If it fails because of an invalid Promise manifest referenced, state the reason in the event accordingly.

Add RBAC permissions to `PromiseReleaseReconciler` to `CREATE` and `PATCH` `events` on itself in-cluster.

Fixes 87

## How to test?
### 1. Create clusters and install Kratix.
```
make quick-start
```
### 2. Create `PromiseRelease` with a reference URL to an invalid `Promise` (eg. incorrect label value syntax).
```
git show issue-87-temp:promiserelease.yaml | kubectl apply -f -
```
> Note:  [issue-87-temp][1] is a temporary branch holding a `PromiseRelease` file [here][2], and more importantly, the invalid `Promise` file [here][3]. This is directly applied from the branch and remote. If the branch is missing locally, do a `git fetch` before running the above command.
### 3. Check `Promise` in the cluster.  `Note`: It doesn't get created due to an invalid label, with or without the current changes.
```
kubectl get promises.platform.kratix.io
```
> Note: `Promise` is cluster-scoped.
### 4. Check `PromiseRelease`'s status.
```
kubectl get promisereleases.platform.kratix.io/promise
```
> Note: `PromiseRelease` is cluster-scoped.
#### Earlier
```
NAME      STATUS      VERSION
promise   Installed   v1.0.0+beta.1
```
#### Now
```
NAME      STATUS             VERSION
promise   Error installing   v1.0.0+beta.1
```
### 5. Check `PromiseRelease`'s events.
```
kubectl describe promisereleases.platform.kratix.io/promise
```
#### Earlier
```
Events:                    <none>
```
#### Now
```
Events:
  Type     Reason           Age                From                      Message
  ----     ------           ----               ----                      -------
  Warning  Invalid Promise  1s (x14 over 42s)  PromiseReleaseController  Failed to install Promise "nginx-ingress": Promise.platform.kratix.io "nginx-ingress" is invalid: metadata.labels: Invalid value: "v1.0.0+beta.1": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

[1]: https://github.com/Bhargav-InfraCloud/kratix-ic/tree/issue-87-temp
[2]: https://github.com/Bhargav-InfraCloud/kratix-ic/blob/issue-87-temp/promiserelease.yaml
[3]: https://github.com/Bhargav-InfraCloud/kratix-ic/blob/issue-87-temp/invalid-promise.yaml